### PR TITLE
Added TeslaSwiftVehicle typealias

### DIFF
--- a/Sources/TeslaSwift/Model/Vehicle.swift
+++ b/Sources/TeslaSwift/Model/Vehicle.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+typealias TeslaSwiftVehicle = Vehicle
 open class Vehicle: Codable {
 	
 	open var backseatToken: String?


### PR DESCRIPTION
Without this, there's no way for client code in an Xcode project to name something `Vehicle`, which a client is likely to do. This is because the module `TeslaSwift` contains a class `TeslaSwift`, and client code can’t reference `TeslaSwift.Vehicle`. An alternative would be to nest `Vehicle` inside `TeslaSwift`.